### PR TITLE
Update InfectedHordes.c (Double path causes hologram zombies)

### DIFF
--- a/mpmissions/DayZSurvival.chernarusplus/ScriptedMods/Modules/ServerEvents/InfectedHordes.c
+++ b/mpmissions/DayZSurvival.chernarusplus/ScriptedMods/Modules/ServerEvents/InfectedHordes.c
@@ -93,9 +93,9 @@ class InfectedHordes
 
 				if (oSkin == 5)
 				{
-					AIzmb.SetObjectMaterial( 0, "DZ\\data\\data\\laser.rvmat" );
-					AIzmb.SetObjectMaterial( 1, "DZ\\data\\data\\laser.rvmat" );
-					AIzmb.SetObjectMaterial( 2, "DZ\\data\\data\\laser.rvmat" );
+					AIzmb.SetObjectMaterial( 0, "DZ\\data\\laser.rvmat" );
+					AIzmb.SetObjectMaterial( 1, "DZ\\data\\laser.rvmat" );
+					AIzmb.SetObjectMaterial( 2, "DZ\\data\\laser.rvmat" );
 				}
 			}
 		}


### PR DESCRIPTION
The double "//data" causes some Zeds are Shown as Hologram. This is a fix for this.